### PR TITLE
Security update to fix CWE-601

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17672,7 +17672,7 @@
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
       "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
       "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": ">=1.3.0"
       }
     },
     "node_modules/semver": {
@@ -39587,7 +39587,7 @@
           "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
           "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
           "requires": {
-            "node-forge": "^0.10.0"
+            "node-forge": ">=1.3.0"
           }
         },
         "semver": {
@@ -51937,7 +51937,7 @@
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
       "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": ">=1.3.0"
       }
     },
     "semver": {


### PR DESCRIPTION
Bumped `node-forge` version to `"node-forge": ">=1.3.0"`