### PR TITLE
Security update to fix CVE-2022-25858

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9851,7 +9851,7 @@
         "he": "^1.2.0",
         "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
+        "terser": ">=5.14.2"
       },
       "bin": {
         "html-minifier-terser": "cli.js"
@@ -17300,7 +17300,7 @@
         "jest-worker": "^24.9.0",
         "rollup-pluginutils": "^2.8.2",
         "serialize-javascript": "^4.0.0",
-        "terser": "^4.6.2"
+        "terser": ">=5.14.2"
       },
       "peerDependencies": {
         "rollup": ">=0.66.0 <3"
@@ -19062,7 +19062,7 @@
         "source-map-support": "~0.5.12"
       },
       "bin": {
-        "terser": "bin/terser"
+        "terser": ">=5.14.2"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -19080,7 +19080,7 @@
         "schema-utils": "^3.0.0",
         "serialize-javascript": "^5.0.1",
         "source-map": "^0.6.1",
-        "terser": "^5.3.4",
+        "terser": ">=5.14.2",
         "webpack-sources": "^1.4.3"
       },
       "engines": {
@@ -19197,7 +19197,7 @@
         "source-map-support": "~0.5.20"
       },
       "bin": {
-        "terser": "bin/terser"
+        "terser": ">=5.14.2"
       },
       "engines": {
         "node": ">=10"
@@ -21280,7 +21280,7 @@
         "schema-utils": "^1.0.0",
         "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
-        "terser": "^4.1.2",
+        "terser": ">=5.14.2",
         "webpack-sources": "^1.4.0",
         "worker-farm": "^1.7.0"
       },
@@ -33570,7 +33570,7 @@
             "he": "^1.2.0",
             "param-case": "^3.0.3",
             "relateurl": "^0.2.7",
-            "terser": "^4.6.3"
+            "terser": ">=5.14.2"
           }
         },
         "html-tags": {
@@ -39302,7 +39302,7 @@
             "jest-worker": "^24.9.0",
             "rollup-pluginutils": "^2.8.2",
             "serialize-javascript": "^4.0.0",
-            "terser": "^4.6.2"
+            "terser": ">=5.14.2"
           },
           "dependencies": {
             "jest-worker": {
@@ -40744,7 +40744,7 @@
             "schema-utils": "^3.0.0",
             "serialize-javascript": "^5.0.1",
             "source-map": "^0.6.1",
-            "terser": "^5.3.4",
+            "terser": ">=5.14.2",
             "webpack-sources": "^1.4.3"
           },
           "dependencies": {
@@ -41904,7 +41904,7 @@
                 "schema-utils": "^1.0.0",
                 "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
-                "terser": "^4.1.2",
+                "terser": ">=5.14.2",
                 "webpack-sources": "^1.4.0",
                 "worker-farm": "^1.7.0"
               }
@@ -45920,7 +45920,7 @@
         "he": "^1.2.0",
         "param-case": "^3.0.3",
         "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
+        "terser": ">=5.14.2"
       }
     },
     "html-tags": {
@@ -51652,7 +51652,7 @@
         "jest-worker": "^24.9.0",
         "rollup-pluginutils": "^2.8.2",
         "serialize-javascript": "^4.0.0",
-        "terser": "^4.6.2"
+        "terser": ">=5.14.2"
       },
       "dependencies": {
         "jest-worker": {
@@ -53094,7 +53094,7 @@
         "schema-utils": "^3.0.0",
         "serialize-javascript": "^5.0.1",
         "source-map": "^0.6.1",
-        "terser": "^5.3.4",
+        "terser": ">=5.14.2",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
@@ -54254,7 +54254,7 @@
             "schema-utils": "^1.0.0",
             "serialize-javascript": "^4.0.0",
             "source-map": "^0.6.1",
-            "terser": "^4.1.2",
+            "terser": ">=5.14.2",
             "webpack-sources": "^1.4.0",
             "worker-farm": "^1.7.0"
           }


### PR DESCRIPTION
Bumped `terser` version to `"terser": ">=5.14.2"`